### PR TITLE
Removing custom hooks from mutations

### DIFF
--- a/src/Mutation/AttachmentAvatarDelete.php
+++ b/src/Mutation/AttachmentAvatarDelete.php
@@ -2,15 +2,13 @@
 /**
  * AttachmentAvatarDelete Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\AttachmentMutation;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Model\Attachment;
@@ -39,7 +37,7 @@ class AttachmentAvatarDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'object'   => [
 				'type'        => [ 'non_null' => 'AttachmentAvatarEnum' ],
@@ -57,7 +55,7 @@ class AttachmentAvatarDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'deleted' => [
 				'type'        => 'Boolean',
@@ -82,7 +80,7 @@ class AttachmentAvatarDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
 			$object_id = $input['objectId'];
 			$object    = $input['object'];
@@ -112,16 +110,6 @@ class AttachmentAvatarDelete {
 			if ( false === $deleted ) {
 				throw new UserError( __( 'Could not delete the attachment avatar.', 'wp-graphql-buddypress' ) );
 			}
-
-			/**
-			 * Fires after an attachment avatar is deleted.
-			 *
-			 * @param Attachment  $previous_attachment The previous deleted attachment object.
-			 * @param array       $input               The input of the mutation.
-			 * @param AppContext  $context             The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info                The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_attachment_avatar_delete_mutation', $previous_attachment, $input, $context, $info );
 
 			// The deleted attachment avatar status and the previous object.
 			return [

--- a/src/Mutation/AttachmentAvatarUpload.php
+++ b/src/Mutation/AttachmentAvatarUpload.php
@@ -2,15 +2,13 @@
 /**
  * AttachmentAvatarUpload Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\AttachmentMutation;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 
@@ -78,7 +76,7 @@ class AttachmentAvatarUpload {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
 			$object_id    = $input['objectId'];
 			$object       = $input['object'];
@@ -106,15 +104,6 @@ class AttachmentAvatarUpload {
 
 			// Try to upload the avatar image file.
 			AttachmentMutation::upload_avatar_from_file( $input, $object, $object_id );
-
-			/**
-			 * Fires after an attachment avatar is uploaded.
-			 *
-			 * @param array       $input    The input of the mutation.
-			 * @param AppContext  $context  The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info     The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_attachment_avatar_create_mutation', $input, $context, $info );
 
 			return [
 				'id'     => $object_id,

--- a/src/Mutation/AttachmentCoverDelete.php
+++ b/src/Mutation/AttachmentCoverDelete.php
@@ -2,15 +2,13 @@
 /**
  * AttachmentCoverDelete Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\AttachmentMutation;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Model\Attachment;
@@ -39,7 +37,7 @@ class AttachmentCoverDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'objectId' => [
 				'type'        => [ 'non_null' => 'Int' ],
@@ -57,7 +55,7 @@ class AttachmentCoverDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'deleted' => [
 				'type'        => 'Boolean',
@@ -82,7 +80,7 @@ class AttachmentCoverDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
 			$object_id = $input['objectId'];
 			$object    = $input['object'];
@@ -113,16 +111,6 @@ class AttachmentCoverDelete {
 			if ( false === $deleted ) {
 				throw new UserError( __( 'Could not delete the attachment cover.', 'wp-graphql-buddypress' ) );
 			}
-
-			/**
-			 * Fires after an attachment cover is deleted.
-			 *
-			 * @param Attachment  $previous_attachment The deleted attachment object.
-			 * @param array       $input               The input of the mutation.
-			 * @param AppContext  $context             The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info                The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_attachment_cover_delete_mutation', $previous_attachment, $input, $context, $info );
 
 			// The deleted attachment cover status and the previous object.
 			return [

--- a/src/Mutation/AttachmentCoverUpload.php
+++ b/src/Mutation/AttachmentCoverUpload.php
@@ -2,15 +2,13 @@
 /**
  * AttachmentCoverUpload Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\AttachmentMutation;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 
@@ -78,7 +76,7 @@ class AttachmentCoverUpload {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
 			$object_id = $input['objectId'];
 			$object    = $input['object'];
@@ -105,15 +103,6 @@ class AttachmentCoverUpload {
 
 			// Try to upload the cover image file.
 			AttachmentMutation::upload_cover_from_file( $input, $object, $object_id );
-
-			/**
-			 * Fires after an attachment cover is uploaded.
-			 *
-			 * @param array       $input    The input of the mutation.
-			 * @param AppContext  $context  The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info     The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_attachment_cover_create_mutation', $input, $context, $info );
 
 			return [
 				'id'     => $object_id,

--- a/src/Mutation/FriendshipDelete.php
+++ b/src/Mutation/FriendshipDelete.php
@@ -2,17 +2,16 @@
 /**
  * FriendshipDelete Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\FriendshipMutation;
 use WPGraphQL\Extensions\BuddyPress\Model\Friendship;
+use BP_Friends_Friendship;
 
 /**
  * FriendshipDelete Class.
@@ -38,7 +37,7 @@ class FriendshipDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'initiatorId' => [
 				'type'        => [ 'non_null' => 'Int' ],
@@ -56,7 +55,7 @@ class FriendshipDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'deleted' => [
 				'type' => 'Boolean',
@@ -81,7 +80,7 @@ class FriendshipDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
 			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
@@ -102,7 +101,7 @@ class FriendshipDelete {
 			}
 
 			// Check friendship status.
-			$friendship_status = \BP_Friends_Friendship::check_is_friend( $initiator_id->ID, $friend_id->ID );
+			$friendship_status = BP_Friends_Friendship::check_is_friend( $initiator_id->ID, $friend_id->ID );
 
 			// Confirm status.
 			if ( 'not_friends' === $friendship_status ) {
@@ -110,8 +109,8 @@ class FriendshipDelete {
 			}
 
 			// Get friendship.
-			$friendship = new \BP_Friends_Friendship(
-				\BP_Friends_Friendship::get_friendship_id( $initiator_id->ID, $friend_id->ID )
+			$friendship = new BP_Friends_Friendship(
+				BP_Friends_Friendship::get_friendship_id( $initiator_id->ID, $friend_id->ID )
 			);
 
 			// Get and save the friendship object before it is deleted.
@@ -134,19 +133,9 @@ class FriendshipDelete {
 			}
 
 			// Trying to delete the friendship.
-			if ( ! $deleted ) {
+			if ( false === $deleted ) {
 				throw new UserError( __( 'Friendship could not be deleted.', 'wp-graphql-buddypress' ) );
 			}
-
-			/**
-			 * Fires after a friendship is deleted.
-			 *
-			 * @param Friendship  $previous_friendship The deleted friendship model object.
-			 * @param array       $input               The input of the mutation.
-			 * @param AppContext  $context             The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info                The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_friends_delete_mutation', $previous_friendship, $input, $context, $info );
 
 			// The deleted friendship status and the previous friendship object.
 			return [

--- a/src/Mutation/GroupCreate.php
+++ b/src/Mutation/GroupCreate.php
@@ -2,14 +2,13 @@
 /**
  * GroupCreate Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Data\GroupMutation;
@@ -38,7 +37,7 @@ class GroupCreate {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'creatorId'      => [
 				'type'        => 'Int',
@@ -80,11 +79,11 @@ class GroupCreate {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'group' => [
 				'type'        => 'Group',
-				'description' => __( 'The group that was created.', 'wp-graphql-buddypress' ),
+				'description' => __( 'The group object that was created.', 'wp-graphql-buddypress' ),
 				'resolve'     => function( array $payload, array $args, AppContext $context ) {
 					if ( ! isset( $payload['id'] ) || ! absint( $payload['id'] ) ) {
 						return null;
@@ -102,49 +101,29 @@ class GroupCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Check if user can create a group.
-			 */
+			// Check if user can create a group.
 			if ( false === ( is_user_logged_in() && bp_user_can_create_groups() ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to create groups.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Create group and return its newly created ID.
-			 */
+			// Create group and return its newly created ID.
 			$group_id = groups_create_group(
 				GroupMutation::prepare_group_args( $input, null, 'create' )
 			);
 
-			/**
-			 * Throw an exception if the group failed to be created.
-			 */
-			if ( ! is_numeric( $group_id ) ) {
+			// Throw an exception if the group failed to be created.
+			if ( false === is_numeric( $group_id ) ) {
 				throw new UserError( __( 'Could not create Group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Fires after a group is created.
-			 *
-			 * @param int         $group_id The ID of the group being created.
-			 * @param array       $input    The input of the mutation.
-			 * @param AppContext  $context  The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info     The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_groups_create_mutation', $group_id, $input, $context, $info );
-
-			/**
-			 * Return the group ID.
-			 */
+			// Return the group ID.
 			return [
 				'id' => $group_id,
 			];

--- a/src/Mutation/GroupUpdate.php
+++ b/src/Mutation/GroupUpdate.php
@@ -2,17 +2,17 @@
 /**
  * GroupUpdate Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Data\GroupMutation;
+use BP_Groups_Group;
 
 /**
  * GroupUpdate Class.
@@ -38,7 +38,7 @@ class GroupUpdate {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'id'          => [
 				'type'        => 'ID',
@@ -88,7 +88,7 @@ class GroupUpdate {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'group' => [
 				'type'        => 'Group',
@@ -110,61 +110,37 @@ class GroupUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get the group.
-			 */
+			// Get the group.
 			$group = GroupMutation::get_group_from_input( $input );
 
-			/**
-			 * Confirm if group exists.
-			 */
-			if ( empty( $group->id ) || ! $group instanceof \BP_Groups_Group ) {
+			// Confirm if group exists.
+			if ( empty( $group->id ) || ! $group instanceof BP_Groups_Group ) {
 				throw new UserError( __( 'This group does not exist.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Stop now if a user isn't allowed to update a group.
-			 */
+			// Stop now if a user isn't allowed to update a group.
 			if ( false === GroupMutation::can_update_or_delete_group( $group->creator_id ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to update this group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Update group.
-			 */
+			// Update group.
 			$group_id = groups_create_group(
 				GroupMutation::prepare_group_args( $input, $group, 'update' )
 			);
 
-			/**
-			 * Throw an exception if the group failed to be updated.
-			 */
-			if ( ! is_numeric( $group_id ) ) {
+			// Throw an exception if the group failed to be updated.
+			if ( false === is_numeric( $group_id ) ) {
 				throw new UserError( __( 'Could not update existing group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Fires after a group is updated.
-			 *
-			 * @param \BP_Groups_Group $group   The updated BuddyPress group object.
-			 * @param array            $input   The input of the mutation.
-			 * @param AppContext       $context The AppContext passed down the resolve tree.
-			 * @param ResolveInfo      $info    The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_groups_update_mutation', $group, $input, $context, $info );
-
-			/**
-			 * Return the group ID.
-			 */
+			// Return the group ID.
 			return [
 				'id' => $group_id,
 			];

--- a/src/Mutation/XProfileFieldCreate.php
+++ b/src/Mutation/XProfileFieldCreate.php
@@ -2,14 +2,13 @@
 /**
  * XProfileFieldCreate Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Data\XProfileFieldMutation;
@@ -38,7 +37,7 @@ class XProfileFieldCreate {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'name'      => [
 				'type'        => [ 'non_null' => 'String' ],
@@ -110,7 +109,7 @@ class XProfileFieldCreate {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'field' => [
 				'type'        => 'XProfileField',
@@ -132,54 +131,32 @@ class XProfileFieldCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Check if user can create a XProfile field.
-			 */
+			// Check if user can create a XProfile field.
 			if ( false === XProfileFieldMutation::can_manage_xprofile_field() ) {
 				throw new UserError( __( 'Sorry, you are not allowed to create XProfile fields.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Create XProfile field and return its ID.
-			 */
+			// Create XProfile field and return its ID.
 			$xprofile_field_id = xprofile_insert_field(
 				XProfileFieldMutation::prepare_xprofile_field_args( $input, null, 'create' )
 			);
 
-			/**
-			 * Throw an exception if the XProfile field failed to be created.
-			 */
-			if ( ! is_numeric( $xprofile_field_id ) ) {
+			// Throw an exception if the XProfile field failed to be created.
+			if ( false === is_numeric( $xprofile_field_id ) ) {
 				throw new UserError( __( 'Could not create XProfile field.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Save additional information.
-			 */
+			// Save additional information.
 			XProfileFieldMutation::set_additional_fields( $xprofile_field_id, $input );
 
-			/**
-			 * Fires after a XProfile field is created.
-			 *
-			 * @param int         $xprofile_field_id The ID of the XProfile field being created.
-			 * @param array       $input            The input of the mutation.
-			 * @param AppContext  $context          The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info             The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_xprofile_fields_create_mutation', $xprofile_field_id, $input, $context, $info );
-
-			/**
-			 * Return the XProfile field ID.
-			 */
+			// Return the XProfile field ID.
 			return [
 				'id' => $xprofile_field_id,
 			];

--- a/src/Mutation/XProfileFieldDelete.php
+++ b/src/Mutation/XProfileFieldDelete.php
@@ -2,15 +2,13 @@
 /**
  * XProfileFieldDelete Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\XProfileFieldMutation;
 use WPGraphQL\Extensions\BuddyPress\Model\XProfileField;
 
@@ -38,7 +36,7 @@ class XProfileFieldDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'id' => [
 				'type' => 'ID',
@@ -60,7 +58,7 @@ class XProfileFieldDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'deleted' => [
 				'type'        => 'Boolean',
@@ -85,59 +83,35 @@ class XProfileFieldDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get the XProfile field object.
-			 */
+			// Get the XProfile field object.
 			$xprofile_field_object = XProfileFieldMutation::get_xprofile_field_from_input( $input );
 
-			/**
-			 * Confirm if XProfile field exists.
-			 */
+			// Confirm if XProfile field exists.
 			if ( empty( $xprofile_field_object->id ) ) {
 				throw new UserError( __( 'This XProfile field does not exist.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Stop now if a user isn't allowed to delete a XProfile field.
-			 */
+			// Stop now if a user isn't allowed to delete a XProfile field.
 			if ( false === XProfileFieldMutation::can_manage_xprofile_field() ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete XProfile field.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get a XProfile field object before it is deleted.
-			 */
+			// Get a XProfile field object before it is deleted.
 			$previous_xprofile_field = new XProfileField( $xprofile_field_object );
 
-			/**
-			 * Trying to delete the XProfile field.
-			 */
-			if ( ! $xprofile_field_object->delete( $input['deleteData'] ?? false ) ) {
+			// Trying to delete the XProfile field.
+			if ( false === $xprofile_field_object->delete( $input['deleteData'] ?? false ) ) {
 				throw new UserError( __( 'Could not delete the XProfile field.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Fires after a XProfile field is deleted.
-			 *
-			 * @param XProfileField $previous_xprofile_field The deleted XProfile field model object.
-			 * @param array         $input                   The input of the mutation.
-			 * @param AppContext    $context                 The AppContext passed down the resolve tree.
-			 * @param ResolveInfo   $info                    The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_xprofile_fields_delete_mutation', $previous_xprofile_field, $input, $context, $info );
-
-			/**
-			 * The deleted XProfile field and the previous XProfile field object.
-			 */
+			// The deleted XProfile field and the previous XProfile field object.
 			return [
 				'deleted'        => true,
 				'previousObject' => $previous_xprofile_field,

--- a/src/Mutation/XProfileFieldUpdate.php
+++ b/src/Mutation/XProfileFieldUpdate.php
@@ -2,14 +2,13 @@
 /**
  * XProfileFieldUpdate Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Data\XProfileFieldMutation;
@@ -38,7 +37,7 @@ class XProfileFieldUpdate {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'id' => [
 				'type' => 'ID',
@@ -118,7 +117,7 @@ class XProfileFieldUpdate {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'field' => [
 				'type'        => 'XProfileField',
@@ -140,30 +139,22 @@ class XProfileFieldUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get the XProfile field object.
-			 */
+			// Get the XProfile field object.
 			$xprofile_field_object = XProfileFieldMutation::get_xprofile_field_from_input( $input );
 
-			/**
-			 * Confirm if XProfile field exists.
-			 */
+			// Confirm if XProfile field exists.
 			if ( empty( $xprofile_field_object->id ) ) {
 				throw new UserError( __( 'This XProfile field does not exist.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Check if user can update a XProfile field.
-			 */
+			// Check if user can update a XProfile field.
 			if ( false === XProfileFieldMutation::can_manage_xprofile_field() ) {
 				throw new UserError( __( 'Sorry, you are not allowed to update this XProfile field.', 'wp-graphql-buddypress' ) );
 			}
@@ -173,38 +164,20 @@ class XProfileFieldUpdate {
 				$input['canDelete'] = false;
 			}
 
-			/**
-			 * Create XProfile field and return the ID.
-			 */
+			// Create XProfile field and return the ID.
 			$xprofile_field_id = xprofile_insert_field(
 				XProfileFieldMutation::prepare_xprofile_field_args( $input, $xprofile_field_object, 'update' )
 			);
 
-			/**
-			 * Throw an exception if the XProfile field failed to be updated.
-			 */
-			if ( ! is_numeric( $xprofile_field_id ) ) {
+			// Throw an exception if the XProfile field failed to be updated.
+			if ( false === is_numeric( $xprofile_field_id ) ) {
 				throw new UserError( __( 'Could not update XProfile field.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Save additional information.
-			 */
+			// Save additional information.
 			XProfileFieldMutation::set_additional_fields( $xprofile_field_id, $input );
 
-			/**
-			 * Fires after a XProfile field is updated.
-			 *
-			 * @param int         $xprofile_field_id The ID of the XProfile field being updated.
-			 * @param array       $input             The input of the mutation.
-			 * @param AppContext  $context           The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info              The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_xprofile_fields_update_mutation', $xprofile_field_id, $input, $context, $info );
-
-			/**
-			 * Return the XProfile field ID.
-			 */
+			// Return the XProfile field ID.
 			return [
 				'id' => $xprofile_field_id,
 			];

--- a/src/Mutation/XProfileGroupCreate.php
+++ b/src/Mutation/XProfileGroupCreate.php
@@ -2,14 +2,13 @@
 /**
  * XProfileGroupCreate Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Data\XProfileGroupMutation;
@@ -38,7 +37,7 @@ class XProfileGroupCreate {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'name'      => [
 				'type'        => [ 'non_null' => 'String' ],
@@ -60,7 +59,7 @@ class XProfileGroupCreate {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'group' => [
 				'type'        => 'XProfileGroup',
@@ -82,49 +81,29 @@ class XProfileGroupCreate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function( $input, AppContext $context, ResolveInfo $info ) {
+		return function( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Check if user can create a XProfile group.
-			 */
+			// Check if user can create a XProfile group.
 			if ( false === XProfileGroupMutation::can_manage_xprofile_group() ) {
 				throw new UserError( __( 'Sorry, you are not allowed to create XProfile groups.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Create XProfile group and return the ID.
-			 */
+			// Create XProfile group and return the ID.
 			$xprofile_group_id = xprofile_insert_field_group(
 				XProfileGroupMutation::prepare_xprofile_group_args( $input, null, 'create' )
 			);
 
-			/**
-			 * Throw an exception if the XProfile group failed to be created.
-			 */
-			if ( ! is_numeric( $xprofile_group_id ) ) {
+			// Throw an exception if the XProfile group failed to be created.
+			if ( false === is_numeric( $xprofile_group_id ) ) {
 				throw new UserError( __( 'Cannot create XProfile field group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Fires after a XProfile group is created.
-			 *
-			 * @param int         $xprofile_group_id The ID of the XProfile group being created.
-			 * @param array       $input            The input of the mutation.
-			 * @param AppContext  $context          The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info             The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_xprofile_groups_create_mutation', $xprofile_group_id, $input, $context, $info );
-
-			/**
-			 * Return the XProfile group ID.
-			 */
+			// Return the XProfile group ID.
 			return [
 				'id' => $xprofile_group_id,
 			];

--- a/src/Mutation/XProfileGroupDelete.php
+++ b/src/Mutation/XProfileGroupDelete.php
@@ -2,15 +2,13 @@
 /**
  * XProfileGroupDelete Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\XProfileGroupMutation;
 use WPGraphQL\Extensions\BuddyPress\Model\XProfileGroup;
 
@@ -38,7 +36,7 @@ class XProfileGroupDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'id'      => [
 				'type'        => 'ID',
@@ -56,7 +54,7 @@ class XProfileGroupDelete {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'deleted' => [
 				'type'        => 'Boolean',
@@ -81,59 +79,35 @@ class XProfileGroupDelete {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get the XProfile group object.
-			 */
+			// Get the XProfile group object.
 			$xprofile_group_object = XProfileGroupMutation::get_xprofile_group_from_input( $input );
 
-			/**
-			 * Confirm if XProfile group exists.
-			 */
+			// Confirm if XProfile group exists.
 			if ( empty( $xprofile_group_object->id ) || ! is_object( $xprofile_group_object ) ) {
 				throw new UserError( __( 'This XProfile group does not exist.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Stop now if a user isn't allowed to delete a XProfile group.
-			 */
+			// Stop now if a user isn't allowed to delete a XProfile group.
 			if ( false === XProfileGroupMutation::can_manage_xprofile_group() ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete this XProfile group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get the XProfile group object before it is deleted.
-			 */
+			// Get the XProfile group object before it is deleted.
 			$previous_xprofile_group = new XProfileGroup( $xprofile_group_object );
 
-			/**
-			 * Trying to delete the XProfile group.
-			 */
-			if ( ! xprofile_delete_field_group( $xprofile_group_object->id ) ) {
+			// Trying to delete the XProfile group.
+			if ( false === xprofile_delete_field_group( $xprofile_group_object->id ) ) {
 				throw new UserError( __( 'Could not delete the XProfile group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Fires after a XProfile group is deleted.
-			 *
-			 * @param XProfileGroup $previous_xprofile_group The deleted XProfile group model object.
-			 * @param array          $input                  The input of the mutation.
-			 * @param AppContext     $context                The AppContext passed down the resolve tree.
-			 * @param ResolveInfo    $info                   The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_xprofile_groups_delete_mutation', $previous_xprofile_group, $input, $context, $info );
-
-			/**
-			 * The deleted XProfile group and the previous XProfile group object.
-			 */
+			// The deleted XProfile group and the previous XProfile group object.
 			return [
 				'deleted'        => true,
 				'previousObject' => $previous_xprofile_group,

--- a/src/Mutation/XProfileGroupUpdate.php
+++ b/src/Mutation/XProfileGroupUpdate.php
@@ -2,14 +2,13 @@
 /**
  * XProfileGroupUpdate Mutation.
  *
- * @package \WPGraphQL\Extensions\BuddyPress\Mutation
+ * @package WPGraphQL\Extensions\BuddyPress\Mutation
  * @since 0.0.1-alpha
  */
 
 namespace WPGraphQL\Extensions\BuddyPress\Mutation;
 
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Extensions\BuddyPress\Data\Factory;
 use WPGraphQL\Extensions\BuddyPress\Data\XProfileGroupMutation;
@@ -38,7 +37,7 @@ class XProfileGroupUpdate {
 	 *
 	 * @return array
 	 */
-	public static function get_input_fields() {
+	public static function get_input_fields(): array {
 		return [
 			'id'          => [
 				'type'        => 'ID',
@@ -72,7 +71,7 @@ class XProfileGroupUpdate {
 	 *
 	 * @return array
 	 */
-	public static function get_output_fields() {
+	public static function get_output_fields(): array {
 		return [
 			'group' => [
 				'type'        => 'XProfileGroup',
@@ -94,45 +93,33 @@ class XProfileGroupUpdate {
 	 * @return callable
 	 */
 	public static function mutate_and_get_payload() {
-		return function ( $input, AppContext $context, ResolveInfo $info ) {
+		return function ( $input ) {
 
-			/**
-			 * Throw an exception if there's no input.
-			 */
+			// Throw an exception if there's no input.
 			if ( empty( $input ) || ! is_array( $input ) ) {
 				throw new UserError( __( 'Mutation not processed. There was no input for the mutation.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Get the XProfile group.
-			 */
+			// Get the XProfile group.
 			$xprofile_group_object = XProfileGroupMutation::get_xprofile_group_from_input( $input );
 
-			/**
-			 * Confirm if XProfile group exists.
-			 */
+			// Confirm if XProfile group exists.
 			if ( empty( $xprofile_group_object->id ) || ! is_object( $xprofile_group_object ) ) {
 				throw new UserError( __( 'This XProfile group does not exist.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Stop now if a user isn't allowed to update a XProfile group.
-			 */
+			// Stop now if a user isn't allowed to update a XProfile group.
 			if ( false === XProfileGroupMutation::can_manage_xprofile_group() ) {
 				throw new UserError( __( 'Sorry, you are not allowed to update this XProfile group.', 'wp-graphql-buddypress' ) );
 			}
 
-			/**
-			 * Update XProfile group and return the ID.
-			 */
+			// Update XProfile group and return the ID.
 			$xprofile_group = xprofile_insert_field_group(
 				XProfileGroupMutation::prepare_xprofile_group_args( $input, $xprofile_group_object, 'update' )
 			);
 
-			/**
-			 * Throw an exception if the XProfile group failed to be updated.
-			 */
-			if ( ! $xprofile_group ) {
+			// Throw an exception if the XProfile group failed to be updated.
+			if ( false === $xprofile_group ) {
 				throw new UserError( __( 'Cannot update existing XProfile field group.', 'wp-graphql-buddypress' ) );
 			}
 
@@ -144,19 +131,7 @@ class XProfileGroupUpdate {
 				xprofile_update_field_group_position( $xprofile_group_id, absint( $input['groupOrder'] ) );
 			}
 
-			/**
-			 * Fires after a XProfile group is updated.
-			 *
-			 * @param int         $xprofile_group_id The ID of the XProfile group being updated.
-			 * @param array       $input             The input of the mutation.
-			 * @param AppContext  $context           The AppContext passed down the resolve tree.
-			 * @param ResolveInfo $info              The ResolveInfo passed down the resolve tree.
-			 */
-			do_action( 'bp_graphql_xprofile_groups_update_mutation', $xprofile_group_id, $input, $context, $info );
-
-			/**
-			 * Return the XProfile group ID.
-			 */
+			// Return the XProfile group ID.
 			return [
 				'id' => $xprofile_group_id,
 			];


### PR DESCRIPTION
We are removing our custom hooks from the mutations since the core wpgraphql plugin already takes care of that.