### PR TITLE
Raising WordPress required version to 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ matrix:
       env: WP_VERSION=5.0
     - php: 7.2
       env: WP_VERSION=4.9
-    - php: 7.2
-      env: WP_VERSION=4.8
     - php: 7.1
       env: WP_VERSION=master
     - php: 7.1
@@ -49,8 +47,6 @@ matrix:
       env: WP_VERSION=5.0
     - php: 7.1
       env: WP_VERSION=4.9
-    - php: 7.1
-      env: WP_VERSION=4.8
   allow_failures:
     - php: 7.4
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docs (soon) • <a href="https://ralv.es" target="_blank">Renato Alves</a> • 
 ## System Requirements
 
 * PHP >= 7.1
-* WP >= 4.8
+* WP >= 4.9
 * WPGraphQL >= latest
 * BuddyPress >= latest
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WPGraphQL BuddyPress ===
 Contributors:      espellcaste
 Tags:              graphql, bp graphql, wp-graphql, rest, community, api, buddypress, social networking
-Requires at least: 4.8
+Requires at least: 4.9
 Requires PHP:      7.1
 Tested up to:      5.4
 Stable tag:        0.0.1-alpha

--- a/wp-graphql-buddypress.php
+++ b/wp-graphql-buddypress.php
@@ -16,7 +16,7 @@
  * Text Domain:       wp-graphql-buddypress
  * Domain Path:       /languages/
  * Requires PHP:      7.1
- * Requires WP:       4.8
+ * Requires WP:       4.9
  * Tested up to:      5.4
  * License:           GPLv3
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
As BuddyPress core is raising its support to WordPress 4.9: https://buddypress.trac.wordpress.org/ticket/8318 We are following suit. :)